### PR TITLE
Fix errors when doing pip install from git repository URL.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ spello==1.2.0
 snowballstemmer
 tensorflow
 sentencepiece
+sklearn
+opencv-python

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """ Package setup """
 import os
 # from pip.req import parse_requirements
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 
 with open("README.md", "r", encoding="utf-8") as f:
@@ -20,7 +20,8 @@ setup(
     author_email=['sharmaanix@gmail.com','sushil79g@gmail.com'],
     license='MIT',
     keywords='NLP ml ai nepali',
-    packages=find_packages(exclude=('docs', 'tests', 'env', 'index.py')),
+    packages=find_namespace_packages(exclude=('docs', 'tests', 'env', 'index.py')),
+    package_data={"Nepali_nlp.local_dataset": ["*"]},
     include_package_data=True,
     install_requires=required,
     dependency_links = ["https://github.com/sushil79g/spello_memory.git"],


### PR DESCRIPTION
Installing this repository with `pip install git+https://github.com/sushil79g/Nepali_nlp.git` resulted in errors when loading the library. This pull request makes sure that all required data files and dependencies are installed with the package. Fixes #39.